### PR TITLE
Develop: ContentViewにFloatingAlertを実装

### DIFF
--- a/Reminder Assistant/ContentView.swift
+++ b/Reminder Assistant/ContentView.swift
@@ -5,6 +5,7 @@ struct ContentView: View {
     @State private var deadline = ""
     @State private var notes = ""
     @FocusState private var focus: Focus?
+    @State private var floatingAlertInformation: FloatingAlert.Information?
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
@@ -33,6 +34,24 @@ struct ContentView: View {
             if focus == nil {
                 Button("Show App Settings") {}
                     .foregroundColor(.secondary)
+            }
+        }
+        .overlay {
+            if let info = floatingAlertInformation {
+                Color(colorScheme == .light ? .gray : .black).opacity(0.5)
+                    .ignoresSafeArea()
+                    .onTapGesture {
+                        title.removeAll()
+                        deadline.removeAll()
+                        notes.removeAll()
+                        withAnimation(.easeIn(duration: 0.25)) {
+                            floatingAlertInformation = nil
+                        }
+                    }
+                FloatingAlert(info)
+                    .frame(maxHeight: .infinity)
+                    .ignoresSafeArea()
+                    .transition(.move(edge: .bottom))
             }
         }
     }
@@ -106,6 +125,15 @@ struct ContentView: View {
     var reminderCreateButton: some View {
         Button {
             focus = nil
+            withAnimation(.easeOut(duration: 0.25)) {
+                floatingAlertInformation = .init(
+                    title: "Success!!",
+                    description: "アプリ道場サロン勉強会\n(2024年3月15日 20:00)",
+                    descriptionAlignment: .center,
+                    imageName: "swift",
+                    imageColor: foregroundColor
+                )
+            }
         } label: {
             Text("リマインダー作成")
                 .font(.title3)

--- a/Reminder Assistant/FloatingAlert.swift
+++ b/Reminder Assistant/FloatingAlert.swift
@@ -34,6 +34,15 @@ struct FloatingAlert: View {
         .padding(.top, 35)
     }
 
+    struct Information: Identifiable {
+        let id = UUID()
+        let title: String
+        let description: String
+        let descriptionAlignment: TextAlignment
+        let imageName: String
+        let imageColor: Color
+    }
+
     var titleText: some View {
         ViewThatFits(in: .horizontal) {
             ForEach(0..<10) { i in

--- a/Reminder Assistant/FloatingAlert.swift
+++ b/Reminder Assistant/FloatingAlert.swift
@@ -5,6 +5,8 @@ struct FloatingAlert: View {
     let title: String
     let description: String
     let descriptionAlignment: TextAlignment
+    let imageName: String
+    let imageColor: Color
 
     var body: some View {
         VStack(spacing: 0) {
@@ -43,6 +45,14 @@ struct FloatingAlert: View {
         let imageColor: Color
     }
 
+    init(_ information: Information) {
+        self.title = information.title
+        self.description = information.description
+        self.descriptionAlignment = information.descriptionAlignment
+        self.imageName = information.imageName
+        self.imageColor = information.imageColor
+    }
+
     var titleText: some View {
         ViewThatFits(in: .horizontal) {
             ForEach(0..<10) { i in
@@ -51,12 +61,6 @@ struct FloatingAlert: View {
                     .lineLimit(1)
             }
         }
-    }
-
-    init(title: String, description: String, descriptionAlignment: TextAlignment = .center) {
-        self.title = title
-        self.description = description
-        self.descriptionAlignment = descriptionAlignment
     }
 
     var descriptionText: some View {
@@ -71,10 +75,10 @@ struct FloatingAlert: View {
     @ViewBuilder
     func borderdCircleImage(size: CGFloat, borderColor: Color) -> some View {
         Circle()
-            .foregroundStyle(.blue)
+            .foregroundStyle(imageColor)
             .frame(width: size, height: size)
             .overlay {
-                Image(systemName: "hand.thumbsup.fill")
+                Image(systemName: imageName)
                     .resizable()
                     .scaledToFit()
                     .foregroundStyle(.white)
@@ -86,18 +90,22 @@ struct FloatingAlert: View {
     }
 }
 
-#Preview("Light") {
-    FloatingAlert(
-        title: "Success!!",
-        description: "美容院の予約\n(2024年3月10日 21:00)"
+private let floatingAlertSample = FloatingAlert(
+    .init(
+        title: "Success",
+        description: "美容院の予約\n(2024年3月10日 21:00)",
+        descriptionAlignment: .center,
+        imageName: "hand.thumbsup.fill",
+        imageColor: .blue
     )
-    .preferredColorScheme(.light)
+)
+
+#Preview("Light") {
+    floatingAlertSample
+        .preferredColorScheme(.light)
 }
 
 #Preview("Dark") {
-    FloatingAlert(
-        title: "Success!!",
-        description: "美容院の予約\n(2024年3月10日 21:00)"
-    )
-    .preferredColorScheme(.dark)
+    floatingAlertSample
+        .preferredColorScheme(.dark)
 }

--- a/Reminder Assistant/FloatingAlert.swift
+++ b/Reminder Assistant/FloatingAlert.swift
@@ -36,8 +36,7 @@ struct FloatingAlert: View {
         .padding(.top, 35)
     }
 
-    struct Information: Identifiable {
-        let id = UUID()
+    struct Information {
         let title: String
         let description: String
         let descriptionAlignment: TextAlignment

--- a/Reminder Assistant/FloatingAlert.swift
+++ b/Reminder Assistant/FloatingAlert.swift
@@ -25,7 +25,7 @@ struct FloatingAlert: View {
             .background(backgroundColor)
             .clipShape(RoundedRectangle(cornerRadius: 20))
             .overlay(alignment: .top) {
-                borderdCircleImage(size: 60, borderColor: backgroundColor)
+                borderdCircleImage(size: 60)
                     .padding(.top, -30)
             }
             .shadow(color: .clear, radius: 0)
@@ -73,7 +73,7 @@ struct FloatingAlert: View {
     }
 
     @ViewBuilder
-    func borderdCircleImage(size: CGFloat, borderColor: Color) -> some View {
+    func borderdCircleImage(size: CGFloat) -> some View {
         Circle()
             .foregroundStyle(imageColor)
             .frame(width: size, height: size)
@@ -84,7 +84,7 @@ struct FloatingAlert: View {
                     .foregroundStyle(.white)
                     .padding()
                 Circle()
-                    .stroke(borderColor, lineWidth: 5)
+                    .stroke(backgroundColor, lineWidth: 5)
                     .frame(width: 60, height: 60)
             }
     }

--- a/Reminder Assistant/FloatingAlert.swift
+++ b/Reminder Assistant/FloatingAlert.swift
@@ -57,13 +57,9 @@ struct FloatingAlert: View {
     }
 
     var titleText: some View {
-        ViewThatFits(in: .horizontal) {
-            ForEach(0..<10) { i in
-                Text(title)
-                    .font(.custom("Rockwell-Regular", size: 25 - CGFloat(i)))
-                    .lineLimit(1)
-            }
-        }
+        Text(title)
+            .font(.custom("Rockwell-Regular", size: 25))
+            .lineLimit(1)
     }
 
     var descriptionText: some View {

--- a/Reminder Assistant/FloatingAlert.swift
+++ b/Reminder Assistant/FloatingAlert.swift
@@ -52,6 +52,10 @@ struct FloatingAlert: View {
         self.imageColor = information.imageColor
     }
 
+    var backgroundColor: Color {
+        colorScheme == .light ? .white : .init(red: 0.125, green: 0.125, blue: 0.125)
+    }
+
     var titleText: some View {
         ViewThatFits(in: .horizontal) {
             ForEach(0..<10) { i in
@@ -65,10 +69,6 @@ struct FloatingAlert: View {
     var descriptionText: some View {
         Text(description)
             .multilineTextAlignment(descriptionAlignment)
-    }
-
-    var backgroundColor: Color {
-        colorScheme == .light ? .white : .init(red: 0.125, green: 0.125, blue: 0.125)
     }
 
     @ViewBuilder


### PR DESCRIPTION
- add: FloatingAlert.Informationの作成
- change: FloatingAlertの初期化をFloatingAlert.Informationを用いて行うように変更
- change: borderdCircleImage関数の引数borderColorを削除（以下詳細）
- change: FloatingAlert.InformationのIdentifiable準拠を取り消し（以下詳細）
- feat: ContentViewのFloatingAlertの実装
- chore: FloatingAlert.backgroundColorの位置の変更
- change: FloatingAlert.titleText内のViewThatsFitsの使用を取り止め（以下詳細）
