### PR TITLE
Develop: LabeledTextFieldの修正等

### DIFF
--- a/Reminder Assistant/ContentView.swift
+++ b/Reminder Assistant/ContentView.swift
@@ -25,7 +25,22 @@ struct ContentView: View {
                     .padding()
                 titleTextField
                     .padding(.top, 3)
-                deadlineTextField
+                deadlineTextField     
+                    .toolbar {
+                        ToolbarItem(placement: .keyboard) {
+                            HStack(spacing: 0) {
+                                Spacer()
+                                Text("完了")
+                                    .bold()
+                                    .foregroundStyle(Color.accentColor)
+                                    .onTapGesture {
+                                        focus = nil
+                                    }
+
+                            }
+                            .padding(0)
+                        }
+                    }
                     .padding(.top, 25)
                 noteTextField
                     .padding(.top, 25)

--- a/Reminder Assistant/ContentView.swift
+++ b/Reminder Assistant/ContentView.swift
@@ -167,14 +167,14 @@ struct ContentView: View {
                 .transition(.move(edge: .bottom))
         }
     }
-
+    
     func createReminder() {
-        do {
-            focus = nil
-            guard let deadlineDate = japaneseDateConverter.convert(from: deadline)
-            else { throw JapaneseDateConverterError.failed }
-            try reminderCreateManager.create(title: title, deadline: deadlineDate, notes: notes, destinationListID: destinationListID )
-            withAnimation(.easeOut(duration: 0.25)) {
+        withAnimation(.easeOut(duration: 0.25)) {
+            do {
+                focus = nil
+                guard let deadlineDate = japaneseDateConverter.convert(from: deadline)
+                else { throw JapaneseDateConverterError.failed }
+                try reminderCreateManager.create(title: title, deadline: deadlineDate, notes: notes, destinationListID: destinationListID )
                 floatingAlertInformation = .init(
                     title: "Success!!",
                     description: "\(title)\n(\(deadlineDate))",
@@ -182,10 +182,8 @@ struct ContentView: View {
                     imageName: "hand.thumbsup.fill",
                     imageColor: foregroundColor
                 )
-            }
-            title.removeAll(); deadline.removeAll(); notes.removeAll();
-        } catch {
-            withAnimation(.easeOut(duration: 0.25)) {
+                title.removeAll(); deadline.removeAll(); notes.removeAll();
+            } catch {
                 handleError(error)
             }
         }

--- a/Reminder Assistant/ContentView.swift
+++ b/Reminder Assistant/ContentView.swift
@@ -14,7 +14,7 @@ struct ContentView: View {
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage("autoFocus") private var autoFocus = false
     @State private var isShowSettingView = false
-
+    
     var body: some View {
         ScrollView {
             VStack(spacing: 0) {
@@ -27,19 +27,7 @@ struct ContentView: View {
                     .padding(.top, 3)
                 deadlineTextField     
                     .toolbar {
-                        ToolbarItem(placement: .keyboard) {
-                            HStack(spacing: 0) {
-                                Spacer()
-                                Text("完了")
-                                    .bold()
-                                    .foregroundStyle(Color.accentColor)
-                                    .onTapGesture {
-                                        focus = nil
-                                    }
-
-                            }
-                            .padding(0)
-                        }
+                        completionButton
                     }
                     .padding(.top, 25)
                 noteTextField
@@ -84,21 +72,21 @@ struct ContentView: View {
             if autoFocus == true { focus = .title }
         }
     }
-
+    
     enum FocusedTextField {
         case title, deadline, notes
     }
-
+    
     private enum JapaneseDateConverterError: Error { case failed }
-
+    
     var foregroundColor: Color {
         colorScheme == .light ? .init(red: 64/255, green: 123/255, blue: 255/255) : .init(red: 64/255, green: 123/255, blue: 255/255)
     }
-
+    
     var backgroundColor: Color {
         colorScheme == .light ? .white : .init(red: 0.05, green: 0.05, blue: 0.15)
     }
-
+    
     var headerText: some View {
         ViewThatFits(in: .horizontal) {
             ForEach(0..<15) { i in
@@ -109,13 +97,13 @@ struct ContentView: View {
             }
         }
     }
-
+    
     var resizableImage: some View {
         Image("ApplicationUsers")
             .resizable()
             .scaledToFit()
     }
-
+    
     var titleTextField: some View {
         LabeledTextField(
             title: "名前",
@@ -128,7 +116,7 @@ struct ContentView: View {
         )
         .foregroundStyle(foregroundColor)
     }
-
+    
     var deadlineTextField: some View {
         LabeledTextField(
             title: "期限",
@@ -141,7 +129,7 @@ struct ContentView: View {
         )
         .foregroundStyle(foregroundColor)
     }
-
+    
     var noteTextField: some View {
         LabeledMultipleTextField(
             title: "備考",
@@ -152,7 +140,7 @@ struct ContentView: View {
         )
         .foregroundStyle(foregroundColor)
     }
-
+    
     var reminderCreateButton: some View {
         Button {
             createReminder()
@@ -167,7 +155,7 @@ struct ContentView: View {
         .buttonStyle(.borderedProminent)
         .tint(foregroundColor)
     }
-
+    
     @ViewBuilder
     var floatingAlert: some View {
         if let info = floatingAlertInformation {
@@ -180,6 +168,23 @@ struct ContentView: View {
                 .frame(maxHeight: .infinity)
                 .ignoresSafeArea()
                 .transition(.move(edge: .bottom))
+        }
+    }
+    
+    @ToolbarContentBuilder
+    var completionButton: some ToolbarContent {
+        ToolbarItem(placement: .keyboard) {
+            HStack(spacing: 0) {
+                Spacer()
+                Text("完了")
+                    .bold()
+                    .foregroundStyle(Color.accentColor)
+                    .onTapGesture {
+                        focus = nil
+                    }
+                
+            }
+            .padding(0)
         }
     }
     
@@ -203,7 +208,7 @@ struct ContentView: View {
             }
         }
     }
-
+    
     private let onUnexpectedErrorOccurredFloatingAlertInfomation = FloatingAlert.Information(
         title: "Error!!",
         description: "実行中に予期せぬエラーが発生しました。",
@@ -211,7 +216,7 @@ struct ContentView: View {
         imageName: "exclamationmark.triangle.fill",
         imageColor: .yellow
     )
-
+    
     func handleError(_ error: Error) {
         floatingAlertInformation = if error is JapaneseDateConverterError {
             .init(
@@ -254,7 +259,7 @@ struct ContentView: View {
             onUnexpectedErrorOccurredFloatingAlertInfomation
         }
     }
-
+    
     func didTapFloatingAlertBackgroundAction() {
         withAnimation(.easeIn(duration: 0.25)) {
             floatingAlertInformation = nil

--- a/Reminder Assistant/ContentView.swift
+++ b/Reminder Assistant/ContentView.swift
@@ -200,7 +200,7 @@ struct ContentView: View {
     )
 
     func handleError(_ error: Error) {
-        floatingAlertInformation = if let error = error as? JapaneseDateConverterError {
+        floatingAlertInformation = if error is JapaneseDateConverterError {
             .init(
                 title: "Error!!",
                 description: "リマインダーの作成に失敗しました。期限の記述をご確認ください。",

--- a/Reminder Assistant/LabeledTextField.swift
+++ b/Reminder Assistant/LabeledTextField.swift
@@ -68,6 +68,13 @@ private struct RepresentedUITextField: UIViewRepresentable {
         textField.enablesReturnKeyAutomatically = true
         textField.delegate = context.coordinator
         textField.font = UIFont.preferredFont(forTextStyle: .body)
+        let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 50))
+        toolbar.items = [
+            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+            UIBarButtonItem(title: "完了", style: .done, target: context.coordinator, action: #selector(Coordinator.dismissKeyboard))
+        ]
+        toolbar.sizeToFit()
+        textField.inputAccessoryView = toolbar
         return textField
     }
 
@@ -108,12 +115,19 @@ private struct RepresentedUITextField: UIViewRepresentable {
                 return false
             }
         }
-        
+
         func textFieldDidEndEditing(_ textField: UITextField) {
             self.text.wrappedValue = textField.text ?? ""
         }
     }
 }
+
+extension RepresentedUITextField.Coordinator {
+    @objc func dismissKeyboard() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+}
+
 
 private let labeledTextFieldSample = LabeledTextField(
     title: "期限",

--- a/Reminder Assistant/LabeledTextField.swift
+++ b/Reminder Assistant/LabeledTextField.swift
@@ -91,7 +91,7 @@ private struct RepresentedUITextField: UIViewRepresentable {
     }
 
     class Coordinator: NSObject, UITextFieldDelegate {
-        var text: Binding<String>
+        let text: Binding<String>
         let dismissKeyboardAfterCompletion: Bool
         let onReturnAction: @MainActor () -> Void
 

--- a/Reminder Assistant/LabeledTextField.swift
+++ b/Reminder Assistant/LabeledTextField.swift
@@ -108,6 +108,10 @@ private struct RepresentedUITextField: UIViewRepresentable {
                 return false
             }
         }
+        
+        func textFieldDidEndEditing(_ textField: UITextField) {
+            self.text.wrappedValue = textField.text ?? ""
+        }
     }
 }
 

--- a/Reminder Assistant/SettingsView.swift
+++ b/Reminder Assistant/SettingsView.swift
@@ -34,8 +34,15 @@ struct SettingsView: View {
         }
     }
 
-    @ViewBuilder
     var reminderSection: some View {
+        if let lists, lists.contains(where: { $0.id == destinationListID }) == false {
+            destinationListID.removeAll()
+        }
+        return _reminderSection
+    }
+
+    @ViewBuilder
+    var _reminderSection: some View {
         if let defaultList, let lists {
             Section {
                 Picker("作成先", selection: $destinationListID) {
@@ -50,11 +57,6 @@ struct SettingsView: View {
                 Text("リマインダー")
             } footer: {
                 Text("現在のデフォルトリストは\(Text(defaultList).bold())に設定されています。")
-            }
-            .onAppear {
-                if lists.contains(where: { $0.id == destinationListID }) == false {
-                    destinationListID.removeAll()
-                }
             }
         } else {
             Section {


### PR DESCRIPTION
- **chore: 些細な修正**
- **refactor: ContentView.createReminder内でのwithAnimationの重複に対処**
- **change: SettingsView.reminderSectionの変更（以下詳細）**
- **fix: 入力の確定前に他のテキストフィールドに移動すると、入力が消えてしまう問題を修正**
- **feat: キーボードツールバーに完了ボタンを追加（TextFieldとUITextFieldでは実装方法が異なる）**
- **change: @ToolbarContentBuilderを用いて完了ボタンを切り出し**
- **change: RepresentedUITextField.Coodinator.textを変数から定数に変更**
